### PR TITLE
Update link to Rust Argentina website

### DIFF
--- a/src/rust_arg.md
+++ b/src/rust_arg.md
@@ -4,6 +4,6 @@ Invitamos a los alumnos de la materia y a toda la comunidad de la FIUBA a partic
 
 <div style="text-align:center"><img src="rust-lang-ar-logo.png" width=180/></div>
 
-* [Sitio web](https://rust-lang-ar.github.io/)
+* [Sitio web](https://rust-lang.ar/)
 * [Meetup](https://www.meetup.com/es/Rust-Argentina/)
 * [Grupo de Telegram](https://t.me/rust_lang_ar)


### PR DESCRIPTION
Following the link throws 404. The website seems to no longer be hosted there.

I looked for the current website and updated the link.